### PR TITLE
Corrected bitExpert Blog link to show only posts tagged with Magento.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Magento 2
 * [Atwix blog](http://www.atwix.com/blog/)
 * [Belvg](http://blog.belvg.com/category/magento-news)
 * [Ben Marks](http://bhmarks.com/blog/)
-* [bitExpert AG](https://blog.bitexpert.de/blog/)
+* [bitExpert AG](https://blog.bitexpert.de/blog/tag/magento)
 * [Brideo](http://brideo.co.uk/blog/)
 * [Classyllama](http://www.classyllama.com/blog/category/magento)
 * [Cool Ryan](http://www.coolryan.com/category/magento/)


### PR DESCRIPTION
Since our blog does not contain Magento-only blog posts I thought it makes more sense to add a deeplink to all posts tagged with Magento.