### PR TITLE
Add RDM to tools sections

### DIFF
--- a/resources.csv
+++ b/resources.csv
@@ -101,6 +101,7 @@ Tools,Commercial with freemium/trial,Magicento,https://magicento.com/,PHPStorm p
 Tools,Commercial with freemium/trial,Magerror,https://www.magerror.com,All your Magento reports in one place,
 Tools,Commercial with freemium/trial,Beeline,https://m.academy/beeline-magento-2-phpstorm/,"This PhpStorm plugin allows us to create entire files, classes & blocks with just a few keystrokes.",
 Tools,Commercial with freemium/trial,Tinkerwell,https://tinkerwell.app/,A desktop application that allows you to run PHP code; it includes Magento drivers.,
+Tools,Commercial with freemium/trial,RDM,https://rdm.dev/,Open Source GUI for Redis with automatic Magento Cache and Session decompression and decoding.,
 Security,,Official Magento Security Center,https://magento.com/security,"The dedicated resource to stay abreast of the latest security news, best practices, patch releases and bug fixes",
 Security,,MageReport.com,https://www.magereport.com/,Scan your Magento shop for known security vulnerabilities,
 Security,,Magento Malware Scanner,https://github.com/gwillem/magento-malware-scanner,"Scanner, signatures and the largest Magento malware collection on earth",


### PR DESCRIPTION
RDM allows Magento developers to easily view/debug Redis cache. It supports automatic decompression for Magento Cache and Sessions. More info here uglide/RedisDesktopManager#5028